### PR TITLE
Removed "Sign in with GitHub" text on mobile

### DIFF
--- a/app/assets/stylesheets/_media_queries.scss
+++ b/app/assets/stylesheets/_media_queries.scss
@@ -100,6 +100,12 @@ header {
   @include media($mobile) {
     @include span-columns(2);
   }
+
+  .signin-text {
+    @include media($mobile) {
+      display: none;
+    }
+  }
 }
 
 .user-auth-navbar {

--- a/app/views/layouts/_user_auth_navbar.html.erb
+++ b/app/views/layouts/_user_auth_navbar.html.erb
@@ -13,7 +13,7 @@
         <% end %>
       <% else %>
         <%= link_to login_path do %>
-          <span>Sign in with GitHub</span>
+          <span class="signin-text">Sign in with GitHub</span>
           <%= mega_octicon('mark-github') %>
         <% end %>
       <% end %>


### PR DESCRIPTION
It wrapped in an ugly fashion, so now it's gone.

Thoughts? @tiranno @tarebyte